### PR TITLE
Removed weapon_zs_harpoon

### DIFF
--- a/lua/ulx/modules/sh/azbot.lua
+++ b/lua/ulx/modules/sh/azbot.lua
@@ -8,7 +8,6 @@ if engine.ActiveGamemode() == "zombiesurvival" then
 	end)
 	
 	function ulx.giveHumanLoadout(pl)
-		pl:Give("weapon_zs_harpoon")
 		pl:Give("weapon_zs_peashooter")
 		pl:GiveAmmo(50, "pistol")
 	end


### PR DESCRIPTION
weapon_zs_harpoon doesn't exist in the standard version of Zombie Survival.